### PR TITLE
[OSL-3853] rewrite build deploy portal

### DIFF
--- a/dev-guides/portal/build_and_deploy_portal.md
+++ b/dev-guides/portal/build_and_deploy_portal.md
@@ -1,4 +1,4 @@
 # Build and Deploy: Portal
 
 ## Documentation Links
-- [Deployment](https://github.com/ASFOpenSARlab/opensciencelab-portal-v2/blob/main/README.md#deployments)
+- [How to deploy the portal](https://github.com/ASFOpenSARlab/opensciencelab-portal-v2/blob/main/README.md#deployments), from the OSL Portal GitHub repository


### PR DESCRIPTION
Replaces documentation with a link to the portal V2 README

<img width="1372" height="952" alt="image" src="https://github.com/user-attachments/assets/c7cae3c1-f7ca-4fda-94b9-f65d859cd758" />
